### PR TITLE
DT-881 handle bad json

### DIFF
--- a/create-invalid-json.bash
+++ b/create-invalid-json.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+aws --endpoint-url=http://localhost:4575 sns publish \
+    --topic-arn arn:aws:sns:eu-west-2:000000000000:offender_events \
+    --message-attributes '{"eventType" : { "DataType":"String", "StringValue":"INVALID_JSON"}}' \
+    --message '{"eventType":"INVALID_JSON","eventDatetime":"2020-01-13T11:33:23.790725","whoops this is invalid"}'

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/resource/MessagesController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/resource/MessagesController.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.hmpps.offenderevents.resource
 
-import com.google.common.reflect.TypeToken
-import com.microsoft.applicationinsights.core.dependencies.google.gson.Gson
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Controller
@@ -9,18 +7,11 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.justice.hmpps.offenderevents.service.OffenderEventStore
-import uk.gov.justice.hmpps.offenderevents.service.StoredMessage
 
 data class DisplayMessage(val eventType: String, val messageDetails: Map<String, String>)
 
 @Controller
 class MessagesController(@Value("\${ui.pageSize}") val pageSize: Int) {
-
-  companion object {
-    inline fun <reified T> fromJson(json: String): T {
-      return Gson().fromJson(json, object : TypeToken<T>() {}.type)
-    }
-  }
 
   @Autowired
   private lateinit var offenderEventStore: OffenderEventStore
@@ -32,17 +23,11 @@ class MessagesController(@Value("\${ui.pageSize}") val pageSize: Int) {
       @RequestParam(name = "text-filter", required = false) textFilter: String?) =
       ModelAndView("index",
           mutableMapOf(
-              "displayMessages" to offenderEventStore.getPageOfMessages(includeEventTypeFilter, excludeEventTypeFilter, textFilter, pageSize).map(::transformMessage).toList(),
+              "displayMessages" to offenderEventStore.getPageOfMessages(includeEventTypeFilter, excludeEventTypeFilter, textFilter, pageSize).toList(),
               "allEventTypes" to offenderEventStore.getAllEventTypes(),
               "includeEventTypeFilter" to includeEventTypeFilter,
               "excludeEventTypeFilter" to excludeEventTypeFilter,
               "textFilter" to textFilter
           )
       )
-
-  fun transformMessage(storedMessage: StoredMessage) =
-      fromJson<MutableMap<String, String>>(storedMessage.message.Message)
-          .also { keyValuePairs -> keyValuePairs.remove("eventType") }
-          .let { keyValuePairs -> DisplayMessage(storedMessage.eventType.Value, keyValuePairs.toMap()) }
-
 }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
@@ -36,8 +36,8 @@ class OffenderEventStore(@Value("\${model.cacheSize}") private val cacheSize: In
           .toList()
 
   private fun Map<String, String>.containsText(text: String): Boolean {
-    return this.keys.any { it.contains(text.trim()) }
-        || this.values.any { it.contains(text.trim()) }
+    return this.keys.any { it.contains(text.trim(), ignoreCase = true) }
+        || this.values.any { it.contains(text.trim(), ignoreCase = true) }
   }
 
   private fun transformMessage(message: Message) =

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
@@ -1,31 +1,52 @@
 package uk.gov.justice.hmpps.offenderevents.service
 
+import com.google.common.reflect.TypeToken
+import com.google.gson.Gson
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-
-data class StoredMessage(val eventType: EventType, val message: Message)
+import uk.gov.justice.hmpps.offenderevents.resource.DisplayMessage
 
 @Service
 class OffenderEventStore(@Value("\${model.cacheSize}") private val cacheSize: Int,
-                         private val store: MutableList<StoredMessage> = mutableListOf()) : MutableList<StoredMessage> by store {
+                         private val store: MutableList<DisplayMessage> = mutableListOf()) : MutableList<DisplayMessage> by store {
 
-  override fun add(element: StoredMessage) =
+  companion object {
+    fun fromJson(json: String): MutableMap<String, String> {
+      return try {
+        Gson().fromJson(json, object : TypeToken<MutableMap<String, String>>() {}.type)
+      } catch(e: Exception) {
+        mutableMapOf("BadMessage" to json, "CausedException" to e.toString())
+      }
+    }
+  }
+
+  override fun add(element: DisplayMessage) =
       store.add(element)
           .also { if (store.size > cacheSize) store.removeAt(0) }
 
-  fun handleMessage(message: Message) = add(StoredMessage(message.MessageAttributes.eventType, message))
+  fun handleMessage(message: Message) = add(transformMessage(message))
 
-  fun getPageOfMessages(includeEventTypeFilter: List<String>?, excludeEventTypeFilter: List<String>?, textFilter: String?, pageSize: Int): List<StoredMessage> =
+  fun getPageOfMessages(includeEventTypeFilter: List<String>?, excludeEventTypeFilter: List<String>?, textFilter: String?, pageSize: Int): List<DisplayMessage> =
       store.reversed()
           .asSequence()
-          .filterIfNotEmpty(includeEventTypeFilter) { includeEventTypeFilter!!.contains(it.eventType.Value) }
-          .filterIfNotEmpty(excludeEventTypeFilter) { excludeEventTypeFilter!!.contains(it.eventType.Value).not() }
-          .filterIfNotEmpty(textFilter) { it.message.Message.contains(textFilter!!.trim()) } // The function does the null check, but the compiler doesn't realise hence bang bang
+          .filterIfNotEmpty(includeEventTypeFilter) { includeEventTypeFilter!!.contains(it.eventType) }
+          .filterIfNotEmpty(excludeEventTypeFilter) { excludeEventTypeFilter!!.contains(it.eventType).not() }
+          .filterIfNotEmpty(textFilter) { it.messageDetails.containsText(textFilter!!) }
           .take(pageSize)
           .toList()
 
+  private fun Map<String, String>.containsText(text: String): Boolean {
+    return this.keys.any { it.contains(text.trim()) }
+        || this.values.any { it.contains(text.trim()) }
+  }
+
+  private fun transformMessage(message: Message) =
+      fromJson(message.Message)
+          .also { keyValuePairs -> keyValuePairs.remove("eventType") }
+          .let { keyValuePairs -> DisplayMessage(message.MessageAttributes.eventType.Value, keyValuePairs.toMap()) }
+
   fun getAllEventTypes(): List<String> =
-      store.map { it.eventType.Value }
+      store.map { it.eventType }
           .distinct()
           .sorted()
           .toList()

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -6,3 +6,9 @@ sqs:
 
 aws:
   provider: localstack
+
+ui:
+  pageSize: 10
+
+model:
+  cacheSize: 100

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/ListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/ListenerIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.offenderevents.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.hmpps.offenderevents.resource.DisplayMessage
 
 class ListenerIntegrationTest : IntegrationTest() {
 
@@ -14,8 +15,8 @@ class ListenerIntegrationTest : IntegrationTest() {
     `Wait for empty queue`()
 
     assertThat(eventStore.getPageOfMessages(null, null, null, 1))
-        .extracting<EventType>(StoredMessage::eventType)
-        .containsExactly(EventType("EXTERNAL_MOVEMENT_RECORD-INSERTED"))
+        .extracting<String>(DisplayMessage::eventType)
+        .containsExactly("EXTERNAL_MOVEMENT_RECORD-INSERTED")
 
   }
 

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStoreTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStoreTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.hmpps.offenderevents.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import uk.gov.justice.hmpps.offenderevents.resource.DisplayMessage
 
 class OffenderEventStoreTest {
@@ -83,5 +83,5 @@ class OffenderEventStoreTest {
         .extracting<String>(DisplayMessage::eventType).containsExactlyInAnyOrder("1")
   }
 
-  fun aMessage() = Message("ANY_MESSAGE", "ANY_MESSAGE_ID", MessageAttributes(EventType("ANY_EVENT_TYPE")))
+  private fun aMessage() = Message("ANY_MESSAGE", "ANY_MESSAGE_ID", MessageAttributes(EventType("ANY_EVENT_TYPE")))
 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStoreTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStoreTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.hmpps.offenderevents.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import uk.gov.justice.hmpps.offenderevents.resource.DisplayMessage
 
 class OffenderEventStoreTest {
 
@@ -40,7 +41,7 @@ class OffenderEventStoreTest {
     offenderEventStore.handleMessage(aMessage().copy(MessageAttributes = MessageAttributes(EventType("2"))))
 
     assertThat(offenderEventStore.getPageOfMessages(listOf("1"), null, null, 2))
-        .extracting<EventType>(StoredMessage::eventType).containsExactly(EventType("1"))
+        .extracting<String>(DisplayMessage::eventType).containsExactly("1")
   }
 
   @Test
@@ -50,7 +51,7 @@ class OffenderEventStoreTest {
     offenderEventStore.handleMessage(aMessage().copy(MessageAttributes = MessageAttributes(EventType("3"))))
 
     assertThat(offenderEventStore.getPageOfMessages(listOf("1", "3"), null, null, 3))
-        .extracting<EventType>(StoredMessage::eventType).containsExactlyInAnyOrder(EventType("1"), EventType("3"))
+        .extracting<String>(DisplayMessage::eventType).containsExactlyInAnyOrder("1", "3")
   }
 
   @Test
@@ -59,7 +60,7 @@ class OffenderEventStoreTest {
     offenderEventStore.handleMessage(aMessage().copy(MessageAttributes = MessageAttributes(EventType("2"))))
 
     assertThat(offenderEventStore.getPageOfMessages(null, listOf("1"), null, 2))
-        .extracting<EventType>(StoredMessage::eventType).containsExactly(EventType("2"))
+        .extracting<String>(DisplayMessage::eventType).containsExactly("2")
   }
 
   @Test
@@ -69,7 +70,7 @@ class OffenderEventStoreTest {
     offenderEventStore.handleMessage(aMessage().copy(MessageAttributes = MessageAttributes(EventType("3"))))
 
     assertThat(offenderEventStore.getPageOfMessages(null, listOf("1", "3"), null, 3))
-        .extracting<EventType>(StoredMessage::eventType).containsExactlyInAnyOrder(EventType("2"))
+        .extracting<String>(DisplayMessage::eventType).containsExactlyInAnyOrder("2")
   }
 
   @Test
@@ -79,7 +80,7 @@ class OffenderEventStoreTest {
     offenderEventStore.handleMessage(aMessage().copy(MessageAttributes = MessageAttributes(EventType("3"))))
 
     assertThat(offenderEventStore.getPageOfMessages(listOf("1", "2"), listOf("2", "3"), null, 3))
-        .extracting<EventType>(StoredMessage::eventType).containsExactlyInAnyOrder(EventType("1"))
+        .extracting<String>(DisplayMessage::eventType).containsExactlyInAnyOrder("1")
   }
 
   fun aMessage() = Message("ANY_MESSAGE", "ANY_MESSAGE_ID", MessageAttributes(EventType("ANY_EVENT_TYPE")))

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/UiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/UiIntegrationTest.kt
@@ -107,4 +107,21 @@ class UiIntegrationTest : IntegrationTest() {
     assertThat(response).contains("1200836")
   }
 
+  @Test
+  fun `Should handle invalid json`() {
+    val message1 = "/messages/externalMovement.json".readResourceAsText()
+    val message2 = "/messages/invalidJson.json".readResourceAsText()
+
+
+    awsSqsClient.sendMessage(queueUrl, message1)
+    awsSqsClient.sendMessage(queueUrl, message2)
+
+    `Wait for empty queue`()
+
+    val response = URL("$baseUrl/messages").readText()
+
+    assertThat(response).contains("1200835")
+    assertThat(response).contains("INVALID-JSON")
+  }
+
 }

--- a/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/UiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/hmpps/offenderevents/service/UiIntegrationTest.kt
@@ -124,4 +124,18 @@ class UiIntegrationTest : IntegrationTest() {
     assertThat(response).contains("INVALID-JSON")
   }
 
+  @Test
+  fun `Should filter case insensitively`() {
+    val message1 = "/messages/externalMovement.json".readResourceAsText()
+
+
+    awsSqsClient.sendMessage(queueUrl, message1)
+
+    `Wait for empty queue`()
+
+    val response = URL("$baseUrl/messages?text-filter=EVENTDATETIME").readText()
+
+    assertThat(response).contains("1200835")
+  }
+
 }

--- a/src/test/resources/messages/invalidJson.json
+++ b/src/test/resources/messages/invalidJson.json
@@ -1,0 +1,29 @@
+{
+  "Type": "Notification",
+  "MessageId": "b18d62f0-3059-5c2c-af05-346667bd4a28",
+  "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7",
+  "Message": "{\"eventType\":\"INVALID-JSON\",\"eventDatetime\":\"2020-01-13T11:33:23.790725\",\"this is invalid json\"}",
+  "Timestamp": "2020-01-13T11:33:56.874Z",
+  "SignatureVersion": "1",
+  "Signature": "Qo6lSZTKmjjNKUGewr5WK022bnhcB1756qHjcy91lUyZXW8yHPCUYzy9nZubLg9evh8bdZ9RZiGx6Ast2wcL0FUyP2rMHO7cKCF4tVXq0QeYyRfMaDNNP/N8Zqg16oTlfu51ZOarygqQRNctAiL/Pz4qFc7x1HAf1InoJWD7Sy1IqC2TdpEHVGNtJggdMpLcVUkOKz0uciBT6QunGsYLjVlHT72TZImjff9iVRFKrODzcSZJk6do8ZX6smDZoOZEX8jfq7XcCt9chLcvXXdeF8p+8WTeZJATc2ZB3mK0j5WZgtdwXRh2MLHUku4mBmA8K4twf3vak8EXbw+oC02wIg==",
+  "SigningCertURL": "https://sns.eu-west-2.amazonaws.com/SimpleNotificationService-a86cb10b4e1f29c941702d737128f7b6.pem",
+  "UnsubscribeURL": "https://sns.eu-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-f221e27fcfcf78f6ab4f4c3cc165eee7:92545cfe-de5d-43e1-8339-c366bf0172aa",
+  "MessageAttributes": {
+    "eventType": {
+      "Type": "String",
+      "Value": "INVALID-JSON"
+    },
+    "id": {
+      "Type": "String",
+      "Value": "d6801418-4208-3c8e-6b24-4c3e7e05f534"
+    },
+    "contentType": {
+      "Type": "String",
+      "Value": "text/plain;charset=UTF-8"
+    },
+    "timestamp": {
+      "Type": "Number.java.lang.Long",
+      "Value": "1578915236869"
+    }
+  }
+}


### PR DESCRIPTION
Bad JSON was causing the UI to fall over.  Changed to perform the JSON conversion before storing the message which allows us to store bad messages and also the exception that prevented deserialization.  This means we can display and filter bad messages.