### PR TITLE
SDI-527 fix null pointers

### DIFF
--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/resource/MessagesController.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/resource/MessagesController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.justice.hmpps.offenderevents.service.OffenderEventStore
 
-data class DisplayMessage(val eventType: String, val messageDetails: Map<String, String?> = mapOf(), val topic: String)
+data class DisplayMessage(val eventType: String, val messageId: String, val messageDetails: Map<String, String?> = mapOf(), val topic: String)
 
 @Controller
 class MessagesController(@Value("\${ui.pageSize}") val pageSize: Int) {

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventListener.kt
@@ -25,7 +25,7 @@ class OffenderEventListener(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(queueNames = ["event"], factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(queueNames = ["event"], factory = "hmppsQueueContainerFactoryProxy", maxInflightMessagesPerQueue = "1")
   fun receiveMessage(requestJson: String) {
     log.debug("Offender event received raw message: {}", requestJson)
     val message = gson.fromJson(requestJson, Message::class.java)

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventListener.kt
@@ -25,7 +25,7 @@ class OffenderEventListener(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(queueNames = ["event"], factory = "hmppsQueueContainerFactoryProxy", maxInflightMessagesPerQueue = "1")
+  @SqsListener(queueNames = ["event"], factory = "hmppsQueueContainerFactoryProxy", maxInflightMessagesPerQueue = "1", maxMessagesPerPoll = "1")
   fun receiveMessage(requestJson: String) {
     log.debug("Offender event received raw message: {}", requestJson)
     val message = gson.fromJson(requestJson, Message::class.java)

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
@@ -63,6 +63,8 @@ class OffenderEventStore(
   ): List<DisplayMessage> =
     store.reversed()
       .asSequence()
+      .onEach { it?.eventType ?: log.error("Unable to process stored event $it") }
+      .filter { it?.eventType != null }
       .filterIfNotEmpty(includeEventTypeFilter) { includeEventTypeFilter!!.contains(it.eventType) }
       .filterIfNotEmpty(excludeEventTypeFilter) { excludeEventTypeFilter!!.contains(it.eventType).not() }
       .filterIfNotEmpty(includeTopicFilter) { includeTopicFilter!!.contains(it.topic) }

--- a/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
+++ b/src/main/kotlin/uk/gov/justice/hmpps/offenderevents/service/OffenderEventStore.kt
@@ -63,8 +63,6 @@ class OffenderEventStore(
   ): List<DisplayMessage> =
     store.reversed()
       .asSequence()
-      .onEach { it?.eventType ?: log.error("Unable to process stored event $it") }
-      .filter { it?.eventType != null }
       .filterIfNotEmpty(includeEventTypeFilter) { includeEventTypeFilter!!.contains(it.eventType) }
       .filterIfNotEmpty(excludeEventTypeFilter) { excludeEventTypeFilter!!.contains(it.eventType).not() }
       .filterIfNotEmpty(includeTopicFilter) { includeTopicFilter!!.contains(it.topic) }


### PR DESCRIPTION
We think that using a multi-threaded queue listener with a non-thread safe local event store was corrupting the event store thus causing null messages. To fix this we will oknly handle one message at a time.

Also keep Redis in sync with the local event store so the same messages are loaded after a restart.