### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/offender-events-ui/Chart.yaml
+++ b/helm_deploy/offender-events-ui/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.1.2
 
 dependencies:
   - name: generic-service
-    version: 2.8
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3

--- a/helm_deploy/offender-events-ui/values.yaml
+++ b/helm_deploy/offender-events-ui/values.yaml
@@ -1,4 +1,3 @@
----
 # Values here are the same across all environments
 generic-service:
   nameOverride: offender-events-ui
@@ -8,7 +7,7 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/offender-events-ui
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 8080
 
   ingress:
@@ -46,26 +45,18 @@ generic-service:
       SPRING_DATA_REDIS_PASSWORD: "auth_token"
 
   allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live1-1: "35.178.209.113/32"
-    cloudplatform-live1-2: "3.8.51.207/32"
-    cloudplatform-live1-3: "35.177.252.54/32"
-    unilink-aovpn1: "194.75.210.216/29"
-    unilink-aovpn2: "83.98.63.176/29"
-    unilink-aovpn3: "78.33.10.50/31"
-    unilink-aovpn4: "78.33.10.52/30"
-    unilink-aovpn5: "78.33.10.56/30"
-    unilink-aovpn6: "78.33.10.60/32"
-    unilink-aovpn7: "78.33.32.99/32"
-    unilink-aovpn8: "78.33.32.100/30"
-    unilink-aovpn9: "78.33.32.104/30"
-    unilink-aovpn10: "78.33.32.108/32"
-    unilink-aovpn11: "217.138.45.109/32"
-    unilink-aovpn12: "217.138.45.110/32"
+    unilink-aovpn1: 194.75.210.216/29
+    unilink-aovpn3: 78.33.10.50/31
+    unilink-aovpn4: 78.33.10.52/30
+    unilink-aovpn5: 78.33.10.56/30
+    unilink-aovpn6: 78.33.10.60/32
+    unilink-aovpn7: 78.33.32.99/32
+    unilink-aovpn8: 78.33.32.100/30
+    unilink-aovpn9: 78.33.32.104/30
+    unilink-aovpn10: 78.33.32.108/32
+    groups:
+      - internal
+      - unilink_staff
 
 generic-prometheus-alerts:
   targetApplication: offender-events-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/offender-events-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,unilink_staff`
- The size of the allowlist defined in this file will change: `20 => 9 (11 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- unilink-cf-1
  

- unilink-cf-2
  

- unilink-newcastle-2
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
